### PR TITLE
Add ICU 54.1 and keep build-essential packages on the image

### DIFF
--- a/7.1/52.1/Dockerfile
+++ b/7.1/52.1/Dockerfile
@@ -1,9 +1,9 @@
 FROM php:7.1-cli
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
-ENV BUILD_DEPS="autoconf file g++ gcc libc-dev make pkg-config re2c"
+ENV BUILD_DEPS="autoconf file pkg-config re2c"
 ENV LIB_DEPS="zlib1g-dev libzip-dev"
-ENV TOOL_DEPS="git"
+ENV TOOL_DEPS="git build-essential"
 ENV ICU_RELEASE=52.1
 ENV CXXFLAGS "--std=c++0x"
 

--- a/7.1/53.1/Dockerfile
+++ b/7.1/53.1/Dockerfile
@@ -1,9 +1,9 @@
 FROM php:7.1-cli
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
-ENV BUILD_DEPS="autoconf file g++ gcc libc-dev make pkg-config re2c"
+ENV BUILD_DEPS="autoconf file pkg-config re2c"
 ENV LIB_DEPS="zlib1g-dev libzip-dev"
-ENV TOOL_DEPS="git"
+ENV TOOL_DEPS="git build-essential"
 ENV ICU_RELEASE=53.1
 ENV CXXFLAGS "--std=c++0x"
 

--- a/7.1/54.1/Dockerfile
+++ b/7.1/54.1/Dockerfile
@@ -1,9 +1,9 @@
 FROM php:7.1-cli
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
-ENV BUILD_DEPS="autoconf file g++ gcc libc-dev make pkg-config re2c"
+ENV BUILD_DEPS="autoconf file pkg-config re2c"
 ENV LIB_DEPS="zlib1g-dev libzip-dev"
-ENV TOOL_DEPS="git"
+ENV TOOL_DEPS="git build-essential"
 ENV ICU_RELEASE=54.1
 ENV CXXFLAGS "--std=c++0x"
 

--- a/7.1/55.1/Dockerfile
+++ b/7.1/55.1/Dockerfile
@@ -1,9 +1,9 @@
 FROM php:7.1-cli
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
-ENV BUILD_DEPS="autoconf file g++ gcc libc-dev make pkg-config re2c"
+ENV BUILD_DEPS="autoconf file pkg-config re2c"
 ENV LIB_DEPS="zlib1g-dev libzip-dev"
-ENV TOOL_DEPS="git"
+ENV TOOL_DEPS="git build-essential"
 ENV ICU_RELEASE=55.1
 ENV CXXFLAGS "--std=c++0x"
 

--- a/7.1/57.1/Dockerfile
+++ b/7.1/57.1/Dockerfile
@@ -1,9 +1,9 @@
 FROM php:7.1-cli
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
-ENV BUILD_DEPS="autoconf file g++ gcc libc-dev make pkg-config re2c"
+ENV BUILD_DEPS="autoconf file pkg-config re2c"
 ENV LIB_DEPS="zlib1g-dev libzip-dev"
-ENV TOOL_DEPS="git"
+ENV TOOL_DEPS="git build-essential"
 ENV ICU_RELEASE=57.1
 ENV CXXFLAGS "--std=c++0x"
 

--- a/7.1/58.1/Dockerfile
+++ b/7.1/58.1/Dockerfile
@@ -1,9 +1,9 @@
 FROM php:7.1-cli
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
-ENV BUILD_DEPS="autoconf file g++ gcc libc-dev make pkg-config re2c"
+ENV BUILD_DEPS="autoconf file pkg-config re2c"
 ENV LIB_DEPS="zlib1g-dev libzip-dev"
-ENV TOOL_DEPS="git"
+ENV TOOL_DEPS="git build-essential"
 ENV ICU_RELEASE=58.1
 ENV CXXFLAGS "--std=c++0x"
 

--- a/7.1/58.2/Dockerfile
+++ b/7.1/58.2/Dockerfile
@@ -1,9 +1,9 @@
 FROM php:7.1-cli
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
-ENV BUILD_DEPS="autoconf file g++ gcc libc-dev make pkg-config re2c"
+ENV BUILD_DEPS="autoconf file pkg-config re2c"
 ENV LIB_DEPS="zlib1g-dev libzip-dev"
-ENV TOOL_DEPS="git"
+ENV TOOL_DEPS="git build-essential"
 ENV ICU_RELEASE=58.2
 ENV CXXFLAGS "--std=c++0x"
 

--- a/7.1/59.1/Dockerfile
+++ b/7.1/59.1/Dockerfile
@@ -1,9 +1,9 @@
 FROM php:7.1-cli
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
-ENV BUILD_DEPS="autoconf file g++ gcc libc-dev make pkg-config re2c"
+ENV BUILD_DEPS="autoconf file pkg-config re2c"
 ENV LIB_DEPS="zlib1g-dev libzip-dev"
-ENV TOOL_DEPS="git"
+ENV TOOL_DEPS="git build-essential"
 ENV ICU_RELEASE=59.1
 ENV CXXFLAGS "--std=c++0x"
 

--- a/7.1/60.1/Dockerfile
+++ b/7.1/60.1/Dockerfile
@@ -1,9 +1,9 @@
 FROM php:7.1-cli
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
-ENV BUILD_DEPS="autoconf file g++ gcc libc-dev make pkg-config re2c"
+ENV BUILD_DEPS="autoconf file pkg-config re2c"
 ENV LIB_DEPS="zlib1g-dev libzip-dev"
-ENV TOOL_DEPS="git"
+ENV TOOL_DEPS="git build-essential"
 ENV ICU_RELEASE=60.1
 ENV CXXFLAGS "--std=c++0x"
 

--- a/7.1/60.2/Dockerfile
+++ b/7.1/60.2/Dockerfile
@@ -1,9 +1,9 @@
 FROM php:7.1-cli
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
-ENV BUILD_DEPS="autoconf file g++ gcc libc-dev make pkg-config re2c"
+ENV BUILD_DEPS="autoconf file pkg-config re2c"
 ENV LIB_DEPS="zlib1g-dev libzip-dev"
-ENV TOOL_DEPS="git"
+ENV TOOL_DEPS="git build-essential"
 ENV ICU_RELEASE=60.2
 ENV CXXFLAGS "--std=c++0x"
 

--- a/7.1/61.1/Dockerfile
+++ b/7.1/61.1/Dockerfile
@@ -1,9 +1,9 @@
 FROM php:7.1-cli
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
-ENV BUILD_DEPS="autoconf file g++ gcc libc-dev make pkg-config re2c"
+ENV BUILD_DEPS="autoconf file pkg-config re2c"
 ENV LIB_DEPS="zlib1g-dev libzip-dev"
-ENV TOOL_DEPS="git"
+ENV TOOL_DEPS="git build-essential"
 ENV ICU_RELEASE=61.1
 ENV CXXFLAGS "--std=c++0x"
 

--- a/7.1/62.1/Dockerfile
+++ b/7.1/62.1/Dockerfile
@@ -1,9 +1,9 @@
 FROM php:7.1-cli
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
-ENV BUILD_DEPS="autoconf file g++ gcc libc-dev make pkg-config re2c"
+ENV BUILD_DEPS="autoconf file pkg-config re2c"
 ENV LIB_DEPS="zlib1g-dev libzip-dev"
-ENV TOOL_DEPS="git"
+ENV TOOL_DEPS="git build-essential"
 ENV ICU_RELEASE=62.1
 ENV CXXFLAGS "--std=c++0x"
 

--- a/7.1/63.1/Dockerfile
+++ b/7.1/63.1/Dockerfile
@@ -1,9 +1,9 @@
 FROM php:7.1-cli
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
-ENV BUILD_DEPS="autoconf file g++ gcc libc-dev make pkg-config re2c"
+ENV BUILD_DEPS="autoconf file pkg-config re2c"
 ENV LIB_DEPS="zlib1g-dev libzip-dev"
-ENV TOOL_DEPS="git"
+ENV TOOL_DEPS="git build-essential"
 ENV ICU_RELEASE=63.1
 ENV CXXFLAGS "--std=c++0x"
 

--- a/7.1/64.1/Dockerfile
+++ b/7.1/64.1/Dockerfile
@@ -1,0 +1,20 @@
+FROM php:7.1-cli
+
+ENV COMPOSER_ALLOW_SUPERUSER 1
+ENV BUILD_DEPS="autoconf file pkg-config re2c"
+ENV LIB_DEPS="zlib1g-dev libzip-dev"
+ENV TOOL_DEPS="git build-essential"
+ENV ICU_RELEASE=64.1
+ENV CXXFLAGS "--std=c++0x"
+
+RUN apt-get update && apt-get install -y --no-install-recommends $BUILD_DEPS $LIB_DEPS $TOOL_DEPS && rm -rf /var/lib/apt/lists/* \
+ && echo "date.timezone=Europe/Warsaw" >> $PHP_INI_DIR/php.ini \
+ && docker-php-ext-install zip \
+ && cd /tmp && curl -Ls http://download.icu-project.org/files/icu4c/$ICU_RELEASE/icu4c-$(echo $ICU_RELEASE | tr '.' '_')-src.tgz > icu4c-src.tgz \
+ && cd /tmp && tar xzf icu4c-src.tgz && cd /tmp/icu/source && ./configure && make && make install && rm -rf /tmp/icu /tmp/icu4c-src.tgz \
+ && docker-php-ext-configure intl && docker-php-ext-install intl \
+ && apt-get purge -y --auto-remove $BUILD_DEPS
+
+COPY --from=composer /usr/bin/composer /usr/bin/composer
+
+CMD icu-config --version && php -i | grep 'ICU version'

--- a/7.2/52.1/Dockerfile
+++ b/7.2/52.1/Dockerfile
@@ -1,9 +1,9 @@
 FROM php:7.2-cli
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
-ENV BUILD_DEPS="autoconf file g++ gcc libc-dev make pkg-config re2c"
+ENV BUILD_DEPS="autoconf file pkg-config re2c"
 ENV LIB_DEPS="zlib1g-dev libzip-dev"
-ENV TOOL_DEPS="git"
+ENV TOOL_DEPS="git build-essential"
 ENV ICU_RELEASE=52.1
 ENV CXXFLAGS "--std=c++0x"
 

--- a/7.2/53.1/Dockerfile
+++ b/7.2/53.1/Dockerfile
@@ -1,9 +1,9 @@
 FROM php:7.2-cli
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
-ENV BUILD_DEPS="autoconf file g++ gcc libc-dev make pkg-config re2c"
+ENV BUILD_DEPS="autoconf file pkg-config re2c"
 ENV LIB_DEPS="zlib1g-dev libzip-dev"
-ENV TOOL_DEPS="git"
+ENV TOOL_DEPS="git build-essential"
 ENV ICU_RELEASE=53.1
 ENV CXXFLAGS "--std=c++0x"
 

--- a/7.2/54.1/Dockerfile
+++ b/7.2/54.1/Dockerfile
@@ -1,9 +1,9 @@
 FROM php:7.2-cli
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
-ENV BUILD_DEPS="autoconf file g++ gcc libc-dev make pkg-config re2c"
+ENV BUILD_DEPS="autoconf file pkg-config re2c"
 ENV LIB_DEPS="zlib1g-dev libzip-dev"
-ENV TOOL_DEPS="git"
+ENV TOOL_DEPS="git build-essential"
 ENV ICU_RELEASE=54.1
 ENV CXXFLAGS "--std=c++0x"
 

--- a/7.2/55.1/Dockerfile
+++ b/7.2/55.1/Dockerfile
@@ -1,9 +1,9 @@
 FROM php:7.2-cli
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
-ENV BUILD_DEPS="autoconf file g++ gcc libc-dev make pkg-config re2c"
+ENV BUILD_DEPS="autoconf file pkg-config re2c"
 ENV LIB_DEPS="zlib1g-dev libzip-dev"
-ENV TOOL_DEPS="git"
+ENV TOOL_DEPS="git build-essential"
 ENV ICU_RELEASE=55.1
 ENV CXXFLAGS "--std=c++0x"
 

--- a/7.2/57.1/Dockerfile
+++ b/7.2/57.1/Dockerfile
@@ -1,9 +1,9 @@
 FROM php:7.2-cli
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
-ENV BUILD_DEPS="autoconf file g++ gcc libc-dev make pkg-config re2c"
+ENV BUILD_DEPS="autoconf file pkg-config re2c"
 ENV LIB_DEPS="zlib1g-dev libzip-dev"
-ENV TOOL_DEPS="git"
+ENV TOOL_DEPS="git build-essential"
 ENV ICU_RELEASE=57.1
 ENV CXXFLAGS "--std=c++0x"
 

--- a/7.2/58.1/Dockerfile
+++ b/7.2/58.1/Dockerfile
@@ -1,9 +1,9 @@
 FROM php:7.2-cli
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
-ENV BUILD_DEPS="autoconf file g++ gcc libc-dev make pkg-config re2c"
+ENV BUILD_DEPS="autoconf file pkg-config re2c"
 ENV LIB_DEPS="zlib1g-dev libzip-dev"
-ENV TOOL_DEPS="git"
+ENV TOOL_DEPS="git build-essential"
 ENV ICU_RELEASE=58.1
 ENV CXXFLAGS "--std=c++0x"
 

--- a/7.2/58.2/Dockerfile
+++ b/7.2/58.2/Dockerfile
@@ -1,9 +1,9 @@
 FROM php:7.2-cli
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
-ENV BUILD_DEPS="autoconf file g++ gcc libc-dev make pkg-config re2c"
+ENV BUILD_DEPS="autoconf file pkg-config re2c"
 ENV LIB_DEPS="zlib1g-dev libzip-dev"
-ENV TOOL_DEPS="git"
+ENV TOOL_DEPS="git build-essential"
 ENV ICU_RELEASE=58.2
 ENV CXXFLAGS "--std=c++0x"
 

--- a/7.2/59.1/Dockerfile
+++ b/7.2/59.1/Dockerfile
@@ -1,9 +1,9 @@
 FROM php:7.2-cli
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
-ENV BUILD_DEPS="autoconf file g++ gcc libc-dev make pkg-config re2c"
+ENV BUILD_DEPS="autoconf file pkg-config re2c"
 ENV LIB_DEPS="zlib1g-dev libzip-dev"
-ENV TOOL_DEPS="git"
+ENV TOOL_DEPS="git build-essential"
 ENV ICU_RELEASE=59.1
 ENV CXXFLAGS "--std=c++0x"
 

--- a/7.2/60.1/Dockerfile
+++ b/7.2/60.1/Dockerfile
@@ -1,9 +1,9 @@
 FROM php:7.2-cli
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
-ENV BUILD_DEPS="autoconf file g++ gcc libc-dev make pkg-config re2c"
+ENV BUILD_DEPS="autoconf file pkg-config re2c"
 ENV LIB_DEPS="zlib1g-dev libzip-dev"
-ENV TOOL_DEPS="git"
+ENV TOOL_DEPS="git build-essential"
 ENV ICU_RELEASE=60.1
 ENV CXXFLAGS "--std=c++0x"
 

--- a/7.2/60.2/Dockerfile
+++ b/7.2/60.2/Dockerfile
@@ -1,9 +1,9 @@
 FROM php:7.2-cli
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
-ENV BUILD_DEPS="autoconf file g++ gcc libc-dev make pkg-config re2c"
+ENV BUILD_DEPS="autoconf file pkg-config re2c"
 ENV LIB_DEPS="zlib1g-dev libzip-dev"
-ENV TOOL_DEPS="git"
+ENV TOOL_DEPS="git build-essential"
 ENV ICU_RELEASE=60.2
 ENV CXXFLAGS "--std=c++0x"
 

--- a/7.2/61.1/Dockerfile
+++ b/7.2/61.1/Dockerfile
@@ -1,9 +1,9 @@
 FROM php:7.2-cli
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
-ENV BUILD_DEPS="autoconf file g++ gcc libc-dev make pkg-config re2c"
+ENV BUILD_DEPS="autoconf file pkg-config re2c"
 ENV LIB_DEPS="zlib1g-dev libzip-dev"
-ENV TOOL_DEPS="git"
+ENV TOOL_DEPS="git build-essential"
 ENV ICU_RELEASE=61.1
 ENV CXXFLAGS "--std=c++0x"
 

--- a/7.2/62.1/Dockerfile
+++ b/7.2/62.1/Dockerfile
@@ -1,9 +1,9 @@
 FROM php:7.2-cli
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
-ENV BUILD_DEPS="autoconf file g++ gcc libc-dev make pkg-config re2c"
+ENV BUILD_DEPS="autoconf file pkg-config re2c"
 ENV LIB_DEPS="zlib1g-dev libzip-dev"
-ENV TOOL_DEPS="git"
+ENV TOOL_DEPS="git build-essential"
 ENV ICU_RELEASE=62.1
 ENV CXXFLAGS "--std=c++0x"
 

--- a/7.2/63.1/Dockerfile
+++ b/7.2/63.1/Dockerfile
@@ -1,9 +1,9 @@
 FROM php:7.2-cli
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
-ENV BUILD_DEPS="autoconf file g++ gcc libc-dev make pkg-config re2c"
+ENV BUILD_DEPS="autoconf file pkg-config re2c"
 ENV LIB_DEPS="zlib1g-dev libzip-dev"
-ENV TOOL_DEPS="git"
+ENV TOOL_DEPS="git build-essential"
 ENV ICU_RELEASE=63.1
 ENV CXXFLAGS "--std=c++0x"
 

--- a/7.2/64.1/Dockerfile
+++ b/7.2/64.1/Dockerfile
@@ -1,0 +1,20 @@
+FROM php:7.2-cli
+
+ENV COMPOSER_ALLOW_SUPERUSER 1
+ENV BUILD_DEPS="autoconf file pkg-config re2c"
+ENV LIB_DEPS="zlib1g-dev libzip-dev"
+ENV TOOL_DEPS="git build-essential"
+ENV ICU_RELEASE=64.1
+ENV CXXFLAGS "--std=c++0x"
+
+RUN apt-get update && apt-get install -y --no-install-recommends $BUILD_DEPS $LIB_DEPS $TOOL_DEPS && rm -rf /var/lib/apt/lists/* \
+ && echo "date.timezone=Europe/Warsaw" >> $PHP_INI_DIR/php.ini \
+ && docker-php-ext-install zip \
+ && cd /tmp && curl -Ls http://download.icu-project.org/files/icu4c/$ICU_RELEASE/icu4c-$(echo $ICU_RELEASE | tr '.' '_')-src.tgz > icu4c-src.tgz \
+ && cd /tmp && tar xzf icu4c-src.tgz && cd /tmp/icu/source && ./configure && make && make install && rm -rf /tmp/icu /tmp/icu4c-src.tgz \
+ && docker-php-ext-configure intl && docker-php-ext-install intl \
+ && apt-get purge -y --auto-remove $BUILD_DEPS
+
+COPY --from=composer /usr/bin/composer /usr/bin/composer
+
+CMD icu-config --version && php -i | grep 'ICU version'

--- a/7.3/52.1/Dockerfile
+++ b/7.3/52.1/Dockerfile
@@ -1,9 +1,9 @@
 FROM php:7.3-cli
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
-ENV BUILD_DEPS="autoconf file g++ gcc libc-dev make pkg-config re2c"
+ENV BUILD_DEPS="autoconf file pkg-config re2c"
 ENV LIB_DEPS="zlib1g-dev libzip-dev"
-ENV TOOL_DEPS="git"
+ENV TOOL_DEPS="git build-essential"
 ENV ICU_RELEASE=52.1
 ENV CXXFLAGS "--std=c++0x"
 

--- a/7.3/53.1/Dockerfile
+++ b/7.3/53.1/Dockerfile
@@ -1,9 +1,9 @@
 FROM php:7.3-cli
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
-ENV BUILD_DEPS="autoconf file g++ gcc libc-dev make pkg-config re2c"
+ENV BUILD_DEPS="autoconf file pkg-config re2c"
 ENV LIB_DEPS="zlib1g-dev libzip-dev"
-ENV TOOL_DEPS="git"
+ENV TOOL_DEPS="git build-essential"
 ENV ICU_RELEASE=53.1
 ENV CXXFLAGS "--std=c++0x"
 

--- a/7.3/54.1/Dockerfile
+++ b/7.3/54.1/Dockerfile
@@ -1,9 +1,9 @@
 FROM php:7.3-cli
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
-ENV BUILD_DEPS="autoconf file g++ gcc libc-dev make pkg-config re2c"
+ENV BUILD_DEPS="autoconf file pkg-config re2c"
 ENV LIB_DEPS="zlib1g-dev libzip-dev"
-ENV TOOL_DEPS="git"
+ENV TOOL_DEPS="git build-essential"
 ENV ICU_RELEASE=54.1
 ENV CXXFLAGS "--std=c++0x"
 

--- a/7.3/55.1/Dockerfile
+++ b/7.3/55.1/Dockerfile
@@ -1,9 +1,9 @@
 FROM php:7.3-cli
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
-ENV BUILD_DEPS="autoconf file g++ gcc libc-dev make pkg-config re2c"
+ENV BUILD_DEPS="autoconf file pkg-config re2c"
 ENV LIB_DEPS="zlib1g-dev libzip-dev"
-ENV TOOL_DEPS="git"
+ENV TOOL_DEPS="git build-essential"
 ENV ICU_RELEASE=55.1
 ENV CXXFLAGS "--std=c++0x"
 

--- a/7.3/57.1/Dockerfile
+++ b/7.3/57.1/Dockerfile
@@ -1,9 +1,9 @@
 FROM php:7.3-cli
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
-ENV BUILD_DEPS="autoconf file g++ gcc libc-dev make pkg-config re2c"
+ENV BUILD_DEPS="autoconf file pkg-config re2c"
 ENV LIB_DEPS="zlib1g-dev libzip-dev"
-ENV TOOL_DEPS="git"
+ENV TOOL_DEPS="git build-essential"
 ENV ICU_RELEASE=57.1
 ENV CXXFLAGS "--std=c++0x"
 

--- a/7.3/58.1/Dockerfile
+++ b/7.3/58.1/Dockerfile
@@ -1,9 +1,9 @@
 FROM php:7.3-cli
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
-ENV BUILD_DEPS="autoconf file g++ gcc libc-dev make pkg-config re2c"
+ENV BUILD_DEPS="autoconf file pkg-config re2c"
 ENV LIB_DEPS="zlib1g-dev libzip-dev"
-ENV TOOL_DEPS="git"
+ENV TOOL_DEPS="git build-essential"
 ENV ICU_RELEASE=58.1
 ENV CXXFLAGS "--std=c++0x"
 

--- a/7.3/58.2/Dockerfile
+++ b/7.3/58.2/Dockerfile
@@ -1,9 +1,9 @@
 FROM php:7.3-cli
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
-ENV BUILD_DEPS="autoconf file g++ gcc libc-dev make pkg-config re2c"
+ENV BUILD_DEPS="autoconf file pkg-config re2c"
 ENV LIB_DEPS="zlib1g-dev libzip-dev"
-ENV TOOL_DEPS="git"
+ENV TOOL_DEPS="git build-essential"
 ENV ICU_RELEASE=58.2
 ENV CXXFLAGS "--std=c++0x"
 

--- a/7.3/59.1/Dockerfile
+++ b/7.3/59.1/Dockerfile
@@ -1,9 +1,9 @@
 FROM php:7.3-cli
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
-ENV BUILD_DEPS="autoconf file g++ gcc libc-dev make pkg-config re2c"
+ENV BUILD_DEPS="autoconf file pkg-config re2c"
 ENV LIB_DEPS="zlib1g-dev libzip-dev"
-ENV TOOL_DEPS="git"
+ENV TOOL_DEPS="git build-essential"
 ENV ICU_RELEASE=59.1
 ENV CXXFLAGS "--std=c++0x"
 

--- a/7.3/60.1/Dockerfile
+++ b/7.3/60.1/Dockerfile
@@ -1,9 +1,9 @@
 FROM php:7.3-cli
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
-ENV BUILD_DEPS="autoconf file g++ gcc libc-dev make pkg-config re2c"
+ENV BUILD_DEPS="autoconf file pkg-config re2c"
 ENV LIB_DEPS="zlib1g-dev libzip-dev"
-ENV TOOL_DEPS="git"
+ENV TOOL_DEPS="git build-essential"
 ENV ICU_RELEASE=60.1
 ENV CXXFLAGS "--std=c++0x"
 

--- a/7.3/60.2/Dockerfile
+++ b/7.3/60.2/Dockerfile
@@ -1,9 +1,9 @@
 FROM php:7.3-cli
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
-ENV BUILD_DEPS="autoconf file g++ gcc libc-dev make pkg-config re2c"
+ENV BUILD_DEPS="autoconf file pkg-config re2c"
 ENV LIB_DEPS="zlib1g-dev libzip-dev"
-ENV TOOL_DEPS="git"
+ENV TOOL_DEPS="git build-essential"
 ENV ICU_RELEASE=60.2
 ENV CXXFLAGS "--std=c++0x"
 

--- a/7.3/61.1/Dockerfile
+++ b/7.3/61.1/Dockerfile
@@ -1,9 +1,9 @@
 FROM php:7.3-cli
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
-ENV BUILD_DEPS="autoconf file g++ gcc libc-dev make pkg-config re2c"
+ENV BUILD_DEPS="autoconf file pkg-config re2c"
 ENV LIB_DEPS="zlib1g-dev libzip-dev"
-ENV TOOL_DEPS="git"
+ENV TOOL_DEPS="git build-essential"
 ENV ICU_RELEASE=61.1
 ENV CXXFLAGS "--std=c++0x"
 

--- a/7.3/62.1/Dockerfile
+++ b/7.3/62.1/Dockerfile
@@ -1,9 +1,9 @@
 FROM php:7.3-cli
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
-ENV BUILD_DEPS="autoconf file g++ gcc libc-dev make pkg-config re2c"
+ENV BUILD_DEPS="autoconf file pkg-config re2c"
 ENV LIB_DEPS="zlib1g-dev libzip-dev"
-ENV TOOL_DEPS="git"
+ENV TOOL_DEPS="git build-essential"
 ENV ICU_RELEASE=62.1
 ENV CXXFLAGS "--std=c++0x"
 

--- a/7.3/63.1/Dockerfile
+++ b/7.3/63.1/Dockerfile
@@ -1,9 +1,9 @@
 FROM php:7.3-cli
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
-ENV BUILD_DEPS="autoconf file g++ gcc libc-dev make pkg-config re2c"
+ENV BUILD_DEPS="autoconf file pkg-config re2c"
 ENV LIB_DEPS="zlib1g-dev libzip-dev"
-ENV TOOL_DEPS="git"
+ENV TOOL_DEPS="git build-essential"
 ENV ICU_RELEASE=63.1
 ENV CXXFLAGS "--std=c++0x"
 

--- a/7.3/64.1/Dockerfile
+++ b/7.3/64.1/Dockerfile
@@ -1,0 +1,20 @@
+FROM php:7.3-cli
+
+ENV COMPOSER_ALLOW_SUPERUSER 1
+ENV BUILD_DEPS="autoconf file pkg-config re2c"
+ENV LIB_DEPS="zlib1g-dev libzip-dev"
+ENV TOOL_DEPS="git build-essential"
+ENV ICU_RELEASE=64.1
+ENV CXXFLAGS "--std=c++0x"
+
+RUN apt-get update && apt-get install -y --no-install-recommends $BUILD_DEPS $LIB_DEPS $TOOL_DEPS && rm -rf /var/lib/apt/lists/* \
+ && echo "date.timezone=Europe/Warsaw" >> $PHP_INI_DIR/php.ini \
+ && docker-php-ext-install zip \
+ && cd /tmp && curl -Ls http://download.icu-project.org/files/icu4c/$ICU_RELEASE/icu4c-$(echo $ICU_RELEASE | tr '.' '_')-src.tgz > icu4c-src.tgz \
+ && cd /tmp && tar xzf icu4c-src.tgz && cd /tmp/icu/source && ./configure && make && make install && rm -rf /tmp/icu /tmp/icu4c-src.tgz \
+ && docker-php-ext-configure intl && docker-php-ext-install intl \
+ && apt-get purge -y --auto-remove $BUILD_DEPS
+
+COPY --from=composer /usr/bin/composer /usr/bin/composer
+
+CMD icu-config --version && php -i | grep 'ICU version'

--- a/Dockerfile-intl
+++ b/Dockerfile-intl
@@ -1,9 +1,9 @@
 FROM php:7.2-cli
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
-ENV BUILD_DEPS="autoconf file g++ gcc libc-dev make pkg-config re2c"
+ENV BUILD_DEPS="autoconf file pkg-config re2c"
 ENV LIB_DEPS="zlib1g-dev libzip-dev"
-ENV TOOL_DEPS="git"
+ENV TOOL_DEPS="git build-essential"
 ENV ICU_RELEASE=62.1
 ENV CXXFLAGS "--std=c++0x"
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-ICU_VERSION ?= 63.1
+ICU_VERSION ?= 64.1
 PHP_VERSION ?= 7.3
 
 default: build

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ ICU/Intl versions. These images are not meant to be used on production systems.
 ## Supported versions
 
 * PHP 7.1 - 7.3
-* ICU 52.1 - 63.1
+* ICU 52.1 - 64.1
 
 For older PHP or ICU versions check out the legacy branches:
 
@@ -16,12 +16,12 @@ For older PHP or ICU versions check out the legacy branches:
 ## Usage
 
 Images are tagged with a PHP version and an ICU release separated with a dash.
-For example, the tag for `PHP 7.2` and `ICU 63.1` is `7.2-63.1`.
+For example, the tag for `PHP 7.2` and `ICU 64.1` is `7.2-64.1`.
 
 ```bash
 docker run -it --rm \
   -v `pwd`:/symfony -w /symfony \
-  jakzal/php-intl:7.2-63.1 \
+  jakzal/php-intl:7.2-64.1 \
   ./phpunit /symfony/src/Symfony/Component/Intl/Tests/
 ```
 
@@ -59,11 +59,11 @@ make build
 Build the latest PHP version with a chosen ICU release:
 
 ```bash
-make build ICU_VERSION=63.1
+make build ICU_VERSION=64.1
 ```
 
 Build a chosen PHP version with a chosen ICU release:
 
 ```bash
-make build ICU_VERSION=63.1 PHP_VERSION=7.2
+make build ICU_VERSION=64.1 PHP_VERSION=7.2
 ```

--- a/generate.sh
+++ b/generate.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 PHP_VERSIONS=(7.1 7.2 7.3)
-ICU_RELEASES=(52.1 53.1 54.1 55.1 57.1 58.1 58.2 59.1 60.1 60.2 61.1 62.1 63.1)
+ICU_RELEASES=(52.1 53.1 54.1 55.1 57.1 58.1 58.2 59.1 60.1 60.2 61.1 62.1 63.1 64.1)
 
 for icu_release in "${ICU_RELEASES[@]}"; do
     for php_version in "${PHP_VERSIONS[@]}"; do


### PR DESCRIPTION
* ICU 54.1 release: http://site.icu-project.org/download/64
* build-essential packages will be now kept on the image so it is easier to generate intl resources.